### PR TITLE
add system talk name for BlueZ

### DIFF
--- a/io.trezor.suite.yml
+++ b/io.trezor.suite.yml
@@ -15,6 +15,7 @@ finish-args:
   - --filesystem=xdg-desktop
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
+  - --system-talk-name=org.bluez
 modules:
   - name: unappimage
     buildsystem: simple


### PR DESCRIPTION
This allows the use of the new Trezor Safe 7 when it has been previously paired via BT with the system.