### PR TITLE
add talk org.freedesktop.Flatpak to support pairing of new BT Trezor Devices

### DIFF
--- a/io.trezor.suite.yml
+++ b/io.trezor.suite.yml
@@ -16,6 +16,7 @@ finish-args:
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
   - --system-talk-name=org.bluez
+  - --talk-name=org.freedesktop.Flatpak
 modules:
   - name: unappimage
     buildsystem: simple


### PR DESCRIPTION
Since Bluetooth pairing requires using the system Bluetooth UI, which cannot be accessed through portals, Flatpak-spawn is used to run the commands outside the sandbox.