### PR TITLE
chore: update to Trezor Suite version 26.2.3

### DIFF
--- a/io.trezor.suite.appdata.xml
+++ b/io.trezor.suite.appdata.xml
@@ -77,7 +77,7 @@
     </screenshot>
 
     <screenshot>
-      <image>https://raw.githubusercontent.com/flathub/io.trezor.suite/refs/heads/screenshots/screenshots/dark/01-dashboard-d.png</image>
+      <image>https://raw.githubusercontent.com/flathub/io.trezor.suite/e4525d384fc3f950cb8482954bb614c46377a799/screenshots/dark/01-dashboard-d.png</image>
       <caption>Track your total portfolio balance at a glance</caption>
     </screenshot>
   </screenshots>

--- a/io.trezor.suite.appdata.xml
+++ b/io.trezor.suite.appdata.xml
@@ -88,6 +88,23 @@
 
   
 <releases>
+<release version="26.2.3" date="2026-02-19">
+  <url type="details">https://trezor.io/other/product-updates/trezor-suite-updates/trezor-suite-update-february-2026</url>
+  <description>
+    <p><em>Improvements</em></p>
+    <ul>
+      <li>The transaction list has been redesigned to provide a clearer, more intuitive overview of your transaction history.</li>
+      <li>Trezor device wipe behavior has been unified across platforms for a more consistent and streamlined experience.</li>
+      <li>The labeling system has been enhanced, offering a more robust and user-friendly way to organize assets and transactions.</li>
+      <li>The transaction notifications have been redesigned to improve readability.</li>
+    </ul>
+    <p><em>Bug fixes</em></p>
+    <ul>
+      <li>Minor bugs have been resolved alongside performance optimizations, ensuring a smoother and more reliable experience overall.</li>
+      <li>Missing translations have been added in the Trade section.</li>
+    </ul>
+  </description>
+</release>
 <release version="26.1.2" date="2026-01-22">
   <url type="details">https://trezor.io/other/product-updates/trezor-suite-updates/trezor-suite-update-january-2026</url>
   <description>

--- a/io.trezor.suite.yml
+++ b/io.trezor.suite.yml
@@ -17,6 +17,7 @@ finish-args:
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
   - --system-talk-name=org.bluez
+  - --talk-name=org.freedesktop.secrets
 modules:
   - name: unappimage
     buildsystem: simple
@@ -32,16 +33,16 @@ modules:
     sources:
       - type: extra-data
         only-arches: [x86_64]
-        url: https://data.trezor.io/suite/releases/desktop/v26.1.2/Trezor-Suite-26.1.2-linux-x86_64.AppImage
-        size: 180146554
-        sha256: e4465f9a9dd19b9ee2bfd9296f7a878f0974175aebd050972a428f73ae73637d
+        url: https://data.trezor.io/suite/releases/desktop/v26.2.3/Trezor-Suite-26.2.3-linux-x86_64.AppImage
+        size: 181446867
+        sha256: 602c199d2d92123d36597d18ff78d55f60aaa93024943fbd44220147a5640383
         filename: Trezor-Suite.AppImage
 
       - type: extra-data
         only-arches: [aarch64]
-        url: https://data.trezor.io/suite/releases/desktop/v26.1.2/Trezor-Suite-26.1.2-linux-arm64.AppImage
-        size: 180405236
-        sha256: 5be8a8f2834d87c631a091eca65411a4afa6405b26e82c12e0c63c1a76135dfc
+        url: https://data.trezor.io/suite/releases/desktop/v26.2.3/Trezor-Suite-26.2.3-linux-arm64.AppImage
+        size: 181694612
+        sha256: 3c23fb68b5d37240039c677166c6338f04059c9e0b0c02b1e7f207e695d3f260
         filename: Trezor-Suite.AppImage
 
       - type: script


### PR DESCRIPTION
update to Trezor Suite version 26.2.3

adding `--talk-name=org.freedesktop.secrets` finishing arg so the suite can save Suite sync labels locally encrypted.