### PR TITLE
feat: add scripts for updating changelog and manifest for Trezor Suit…

### DIFF
--- a/.github/scripts/render_release.py
+++ b/.github/scripts/render_release.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Render upstream markdown release notes as an appdata <release> block.
+
+Reads the notes on stdin and writes the block to stdout, matching the markup the
+existing entries use: section headings ("### Title") become <p><em>Title</em></p>
+and bullet lists ("- item") become <ul><li>item</li></ul>, all indented to sit
+inside <releases> and with XML-special characters escaped.
+
+Usage: render_release.py <version> <date> [details-url]   (notes on stdin)
+"""
+import sys
+from xml.sax.saxutils import escape
+
+version, date = sys.argv[1], sys.argv[2]
+details_url = sys.argv[3] if len(sys.argv) > 3 else ""
+
+lines = [f'<release version="{version}" date="{date}">']
+if details_url:
+    lines.append(f"  <url type=\"details\">{escape(details_url)}</url>")
+lines.append("  <description>")
+in_list = False
+
+
+def close_list():
+    global in_list
+    if in_list:
+        lines.append("    </ul>")
+        in_list = False
+
+
+for raw in sys.stdin:
+    text = raw.strip()
+    if not text:
+        continue
+    if text.startswith("#"):  # "### Heading" -> <p><em>Heading</em></p>
+        close_list()
+        title = escape(text.lstrip("#").strip())
+        lines.append(f"    <p><em>{title}</em></p>")
+    elif text.startswith(("- ", "* ")):  # "- bullet" -> <li>bullet</li>
+        if not in_list:
+            lines.append("    <ul>")
+            in_list = True
+        lines.append(f"      <li>{escape(text[2:].strip())}</li>")
+    else:  # any other prose line -> its own paragraph
+        close_list()
+        lines.append(f"    <p>{escape(text)}</p>")
+
+close_list()
+lines += ["  </description>", "</release>"]
+
+if "<li>" not in "".join(lines) and "<p>" not in "".join(lines[2:-2]):
+    sys.exit("no release notes to render")
+
+print("\n".join(lines))

--- a/.github/scripts/update_changelog.sh
+++ b/.github/scripts/update_changelog.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Add a <release> entry for $VERSION to the appdata file, built from the upstream
+# release notes. No-op if that version is already listed.
+#
+# Usage: update_changelog.sh <version> <base-url>
+set -euo pipefail
+
+VERSION="$1"
+BASE_URL="$2"
+APPDATA="io.trezor.suite.appdata.xml"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if grep -q "<release version=\"$VERSION\"" "$APPDATA"; then
+  echo "Release $VERSION is already in $APPDATA, nothing to do."
+  exit 0
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+curl -fsSL "$BASE_URL/v$VERSION/latest-linux.yml" -o "$work/latest-linux.yml"
+date="$(yq -r '.releaseDate' "$work/latest-linux.yml" | cut -c1-10)"
+
+# The product-update article is named after the release month, e.g. 26.6.1 -> June 2026:
+# https://trezor.io/.../trezor-suite-update-june-2026
+months=(_ january february march april may june july august september october november december)
+year_short="${VERSION%%.*}"          # 26.6.1 -> 26
+month_num="${VERSION#*.}"; month_num="${month_num%%.*}"   # 26.6.1 -> 6
+details_url="https://trezor.io/other/product-updates/trezor-suite-updates/trezor-suite-update-${months[month_num]}-20${year_short}"
+
+# Strip emoji from the markdown notes: the pictograph characters themselves, plus
+# the variation-selector / zero-width-joiner / keycap codepoints that glue
+# multi-codepoint emoji together. Upstream headings look like "### <emoji> New features",
+# so removing the emoji leaves a double space; collapse runs of spaces and trim line ends.
+strip_emoji() {
+  perl -CSD -pe '
+    s/\p{Extended_Pictographic}//g;
+    s/[\x{FE00}-\x{FE0F}\x{200D}\x{20E3}]//g;
+    s/ {2,}/ /g;
+    s/ +$//;
+  '
+}
+
+# Turn the markdown notes into a <release> block in this file's house style.
+yq -r '.releaseNotes' "$work/latest-linux.yml" | strip_emoji \
+  | python3 "$HERE/render_release.py" "$VERSION" "$date" "$details_url" > "$work/block.xml"
+[ -s "$work/block.xml" ] || { echo "Got no release notes to insert" >&2; exit 1; }
+cp "$work/block.xml" "$RUNNER_TEMP/block.xml"
+
+# Insert the new entry directly after <releases> so the newest release is first.
+awk -v block="$work/block.xml" '
+  /<releases>/ && !inserted {
+    print
+    while ((getline line < block) > 0) print line
+    inserted = 1
+    next
+  }
+  { print }
+' "$APPDATA" > "$APPDATA.tmp"
+mv "$APPDATA.tmp" "$APPDATA"
+
+echo "Added release $VERSION ($date) to $APPDATA."

--- a/.github/scripts/update_manifest.sh
+++ b/.github/scripts/update_manifest.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Point the Flatpak manifest at a new Trezor Suite release: download each AppImage,
+# then rewrite its url / size / sha256 in the manifest.
+#
+# Usage: update_manifest.sh <version> <base-url>
+set -euo pipefail
+
+VERSION="$1"
+BASE_URL="$2"
+MANIFEST="io.trezor.suite.yml"
+RELEASE_URL="$BASE_URL/v$VERSION"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Point the manifest's extra-data block for one arch at a freshly downloaded AppImage.
+# $arch is the manifest's only-arches value (x86_64 / aarch64); $file is the AppImage name.
+update_arch() {
+  local arch="$1" file="$2"
+  local url="$RELEASE_URL/$file"
+
+  echo "Downloading $url"
+  curl -fL -o "$work/$file" "$url"
+  local size sha
+  size="$(stat -c%s "$work/$file")"
+  sha="$(sha256sum "$work/$file" | awk '{print $1}')"
+  echo "  size=$size sha256=$sha"
+
+  # The block looks like:
+  #   only-arches: [x86_64]
+  #   url: ...
+  #   size: ...
+  #   sha256: ...
+  # Match from the arch marker up to its sha256 and rewrite the three values.
+  # -z so the regex can span the newlines between the fields.
+  sed -i -z "s|only-arches: \[$arch\][^-]*url: [^\n]*Trezor-Suite-[^\n]*.AppImage[^s]*size: [0-9]*[^s]*sha256: [a-f0-9]*|only-arches: [$arch]\n        url: $url\n        size: $size\n        sha256: $sha|" "$MANIFEST"
+}
+
+update_arch x86_64  "Trezor-Suite-$VERSION-linux-x86_64.AppImage"
+update_arch aarch64 "Trezor-Suite-$VERSION-linux-arm64.AppImage"
+
+echo "Updated $MANIFEST to $VERSION."

--- a/.github/workflows/update-suite.yml
+++ b/.github/workflows/update-suite.yml
@@ -1,0 +1,96 @@
+name: Update Trezor Suite
+
+# Bump Trezor Suite: refresh the Flatpak manifest + appdata changelog, open a PR.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to update to (e.g. 26.6.1). Blank = latest upstream release."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Don't let two runs fight over the same branch.
+concurrency:
+  group: update-suite-${{ github.event.inputs.version }}
+  cancel-in-progress: false
+
+env:
+  BASE_URL: https://data.trezor.io/suite/releases/desktop
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  update:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Detect version
+        id: detect
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION=$(curl -fsSL "$BASE_URL/latest/latest-linux.yml" | sed -n 's/^version:[[:space:]]*//p' | head -1)
+          fi
+          [ -n "$VERSION" ] || { echo "Could not determine version" >&2; exit 1; }
+
+          # What's currently shipped, read off the x86_64 AppImage url.
+          CURRENT=$(grep -oP 'desktop/v\K[0-9]+\.[0-9]+\.[0-9]+(?=/Trezor-Suite-[^/]*x86_64\.AppImage)' io.trezor.suite.yml | head -1)
+          echo "Target: $VERSION   Current: $CURRENT"
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [ "$VERSION" = "$CURRENT" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update manifest
+        if: steps.detect.outputs.changed == 'true'
+        run: .github/scripts/update_manifest.sh "${{ steps.detect.outputs.version }}" "$BASE_URL"
+
+      - name: Update changelog
+        if: steps.detect.outputs.changed == 'true'
+        run: .github/scripts/update_changelog.sh "${{ steps.detect.outputs.version }}" "$BASE_URL"
+
+      - name: Validate output
+        if: steps.detect.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          yq -e '.' io.trezor.suite.yml > /dev/null
+          python3 -c "import xml.dom.minidom as m; m.parse('io.trezor.suite.appdata.xml')"
+          # Re-check the entry we just added for emoji (the changelog script stashed it here),
+          # using the same pattern that stripped them so old entries don't fail the run.
+          # No block means the changelog entry already existed, so there's nothing to check.
+          BLOCK="$RUNNER_TEMP/block.xml"
+          if [ -f "$BLOCK" ] && ! perl -CSD -ne 'exit 1 if /\p{Extended_Pictographic}|[\x{FE00}-\x{FE0F}\x{200D}\x{20E3}]/' "$BLOCK"; then
+            echo "Generated release block still contains emoji" >&2
+            exit 1
+          fi
+
+      - name: Create pull request
+        if: steps.detect.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        with:
+          branch: update-suite-${{ steps.detect.outputs.version }}
+          delete-branch: true
+          commit-message: "chore: update to Trezor Suite version ${{ steps.detect.outputs.version }}"
+          title: "chore: update to Trezor Suite version ${{ steps.detect.outputs.version }}"
+          body: |
+            Bumps Trezor Suite to **${{ steps.detect.outputs.version }}**.
+
+            - `io.trezor.suite.yml`: refreshed url / size / sha256 for x86_64 and aarch64.
+            - `io.trezor.suite.appdata.xml`: new `<release>` from upstream notes (emoji stripped).
+
+            Source: `${{ env.BASE_URL }}/v${{ steps.detect.outputs.version }}/latest-linux.yml`


### PR DESCRIPTION
Add workflow to auto-PR new Trezor Suite releases
Adds a manually-triggered GitHub Action that bumps Trezor Suite to a new upstream release and opens a PR — so maintainers only review and merge instead of running the update by hand.